### PR TITLE
Fixed authentication, Set ack flag, Added option to ignore SSL errors

### DIFF
--- a/wetterstation.conf
+++ b/wetterstation.conf
@@ -1,14 +1,14 @@
 ### Settings V2.13.0 -----------------------------------------------------------
  #Debuging einschalten [true/false] / default: false / Ausgabe der Messwerte
   debug=false
- 
+
  #Verhalten bei Kommunikationsfehler [true/false] / default: false / Soll der Datenpunkt automatisch resettet werden?
   RESET_KOMFEHLER=false
- 
+
  #Logging einschalten [true/false] / default: false / schreibt die Datenstrings der Station in eine Datei
   logging=false
 
- #ioBroker-IP und Port der Simple-Restful-API [xxx.xxx.xxx.xxx:xxxxx] 
+ #ioBroker-IP und Port der Simple-Restful-API [xxx.xxx.xxx.xxx:xxxxx]
   IPP=192.168.1.3:8087
 
  #Protokoll der Wetterstation [1/2/9] / 1=Wunderground ; 2=Ecowitt ; 9=DNS / default: 2
@@ -16,7 +16,7 @@
 
  #Anzahl der vorhandenen Zusatzsensoren / default: 0
   ANZAHL_WH31=0
-  ANZAHL_DP35=0  
+  ANZAHL_DP35=0
   ANZAHL_DP40=0
   ANZAHL_DP50=0
   ANZAHL_DP60=0
@@ -28,7 +28,10 @@
 
  #Protokoll (HTTP oder HTTPS) / default: HTTP
   WEB=HTTP
- 
+
+ #Ignoriere Zertifikatsfehler bei der Simple-Restful-API [true/false] / default: false / nötig bei eigenen Zertifikaten
+  WEB_IGN_SSL_ERROR=false
+
  #User-Authentifizierung falls benutzt; sonst leer lassen
   AUTH_USER=
   AUTH_PASS=
@@ -59,7 +62,7 @@
  # DIFF  = gerade eben / vor einer Stunde / vor 23 Stunden / vor einem Tag / vor 12 Tagen
 
   LAST_RAIN=DIFF
- 
+
  #Text-Format für Datenpunkte "Sonnenschein_[Tag|Woche|Monat|Jahr]_Text"
  # zweistellig wird ggf. mit einer führenden "0" aufgefüllt
  # d = Tag(e) 0...n ein- und mehrstellig / h = Stunden 0...n ein- oder mehrstellig
@@ -73,18 +76,18 @@
  # [1] = h:mm                         | 68:02
  # [2] = d Tag/e h Std.               | 2 Tage 20 Std.
  # [3] = d Tag/e, h Std, m Min        | 2 Tage, 20 Std, 2 Min (Anzeige Tage erst bei >0)
-  
+
   SONNENSCHEIN_TXTFORMAT=3
- 
+
 
   #Daten an Wetter.com senden (leer lassen falls nicht gewünscht)?
    WETTERCOM_ID=
    WETTERCOM_PW=
- 
+
  #Fix aktivieren bei fehlerhafter Außentemperatur [true/false] / default: false
  #Bei unplausiblem Messwert wird kein Datenpaket an den ioB geschickt
   FIX_AUSSENTEMP=false
- 
+
 
 
 
@@ -94,7 +97,7 @@
  ###    Für die Registrierung muss "openSenseMap" auf "false" eingestellt sein!            ###
  ###    Erst wenn auch Sensoren angelegt wurden, darf auf "true" umgestellt werden!        ###
  #############################################################################################
-  
+
   #openSenseMap aktivieren [true/false] / default: false
    openSenseMap=false
 
@@ -170,5 +173,5 @@
  #############################################################################################
 
 
-###  Ende Usereinstellungen  
+###  Ende Usereinstellungen
 ###EoF

--- a/wetterstation.sub
+++ b/wetterstation.sub
@@ -178,12 +178,15 @@ function SAPI()
   #2 SAPI-URL
   #3 DATA (setBulk)
 
+  SEP="?"
+  [[ $2 == *"?"* ]] && SEP="&"
+
   if [ "$1" == "Single" ]; then
-   retval=$(curl -s ${WEB}://${IPP}/${2}&user=${AUTH_USER}&pass=${AUTH_PASS} >/dev/null 2>&1)
+   retval=$(curl ${SAPI_CURL_OPTS} -s "${WEB}://${IPP}/${2}${SEP}user=${AUTH_USER}&pass=${AUTH_PASS}" >/dev/null 2>&1)
   fi
 
   if [ "$1" == "Bulk" ]; then
-   curl --data "${3}&user=${AUTH_USER}&pass=${AUTH_PASS}" ${WEB}://${IPP}/${2} >/dev/null 2>&1
+   curl ${SAPI_CURL_OPTS} --data "${3}" "${WEB}://${IPP}/${2}${SEP}user=${AUTH_USER}&pass=${AUTH_PASS}" >/dev/null 2>&1
   fi
 }
 
@@ -243,9 +246,9 @@ iob_send() {
 
    #Daten an den ioB schicken
     if [ $debug == "true" ]; then
-	curl --data "$IOB_DATA&user=${AUTH_USER}&pass=${AUTH_PASS}&prettyPrint" ${WEB}://${IPP}/setBulk
+	curl ${SAPI_CURL_OPTS} --data "$IOB_DATA" "${WEB}://${IPP}/setBulk?ack=true&user=${AUTH_USER}&pass=${AUTH_PASS}&prettyPrint"
       else
-	curl --data "$IOB_DATA&user=${AUTH_USER}&pass=${AUTH_PASS}" ${WEB}://${IPP}/setBulk >/dev/null 2>&1
+	curl ${SAPI_CURL_OPTS} --data "$IOB_DATA" "${WEB}://${IPP}/setBulk?ack=true&user=${AUTH_USER}&pass=${AUTH_PASS}" >/dev/null 2>&1
     fi
 }
 
@@ -328,7 +331,7 @@ convertInchtoMM() {
 	 AKT_TIMESTAMP=`date +%s`
 	 if [ $LAST_RAIN == "DATUM" ]; then LASTRAINMSG=`date "+%d.%m.%Y %H:%M"`; fi
 	 if [ $LAST_RAIN == "UNIX" ]; then LASTRAINMSG=${AKT_TIMESTAMP}; fi
-	 SAPI "Bulk" "setBulk" "${DP_LETZTER_REGEN}=${LASTRAINMSG}&${DP_LETZTE_REGENMENGE}=${MESSWERTE[12]}"
+	 SAPI "Bulk" "setBulk" "${DP_LETZTER_REGEN}=${LASTRAINMSG}&${DP_LETZTE_REGENMENGE}=${MESSWERTE[12]}&ack=true"
 	fi
 
 	if [ $LAST_RAIN == "DIFF" ]; then
@@ -350,7 +353,7 @@ convertInchtoMM() {
 		1)  LASTRAINMSG="vor einem Tag" ;;
 		*)  LASTRAINMSG="vor $TAGE Tagen"
 	   esac
-           SAPI "Bulk" "setBulk" "${DP_LETZTER_REGEN}=${LASTRAINMSG}"
+           SAPI "Bulk" "setBulk" "${DP_LETZTER_REGEN}=${LASTRAINMSG}&ack=true"
 	fi
 
       fi
@@ -459,7 +462,7 @@ wetterprognose() {
 	EOD
 	)
 
-    SAPI "Bulk" "setBulk" "${IOB_WDATA}"
+    SAPI "Bulk" "setBulk" "${IOB_WDATA}&ack=true"
 
 }
 
@@ -493,7 +496,7 @@ sonnenpuls() {
 	 let SONNENSCHEIN_MO+="$SONNENPULS_DIFF"
 	 let SONNENSCHEIN_JAHR+="$SONNENPULS_DIFF"
 	fi
-	SAPI "Bulk" "setBulk" "${DP_SONNENSCHEIN_SAVE}=${SONNENSCHEIN_TAG} ${SONNENSCHEIN_WO} ${SONNENSCHEIN_MO} ${SONNENSCHEIN_JAHR}"
+	SAPI "Bulk" "setBulk" "${DP_SONNENSCHEIN_SAVE}=${SONNENSCHEIN_TAG} ${SONNENSCHEIN_WO} ${SONNENSCHEIN_MO} ${SONNENSCHEIN_JAHR}&ack=true"
 	timestr ${SONNENSCHEIN_TAG} SONNENDAUER_STR_TAG
 	timestr ${SONNENSCHEIN_WO} SONNENDAUER_STR_WO
 	timestr ${SONNENSCHEIN_MO} SONNENDAUER_STR_MO
@@ -505,7 +508,7 @@ sonnenpuls() {
 	EOD
 	)
 	if [ -z $MIDNIGHTRUN ]; then TIMER_START=`date +%s`; fi
-	SAPI "Bulk" "setBulk" "${IOB_SDATA}"
+	SAPI "Bulk" "setBulk" "${IOB_SDATA}&ack=true"
     fi
 
 	###Solarenergie
@@ -541,7 +544,7 @@ sonnenpuls() {
 	EOD
 	)
 
-	SAPI "Bulk" "setBulk" "${IOB_SOLDATA}"
+	SAPI "Bulk" "setBulk" "${IOB_SOLDATA}&ack=true"
     fi
 
 }
@@ -651,6 +654,12 @@ setup() {
   #Anzeige bis Daten komplett
   WETTER_TREND="noch --- Minuten"
 
+  if [ "$WEB_IGN_SSL_ERROR" == "true" ]; then
+    SAPI_CURL_OPTS="-k"
+  else
+    SAPI_CURL_OPTS=""
+  fi
+
   declare -a MESSWERTE
   SOLARENERGIE=(0 0)
   SOLARENERGIE_TS=(0 0)
@@ -679,7 +688,7 @@ setup() {
 
  if [ ${#DRUCKWERTE_TMP} -le "2" ]; then
    DRUCKWERTE_TMP=${DRUCKWERTE[*]}
-   SAPI "Bulk" "setBulk" "${DP_WETTERDATA}=${DRUCKWERTE_TMP}"
+   SAPI "Bulk" "setBulk" "${DP_WETTERDATA}=${DRUCKWERTE_TMP}&ack=true"
   else
    SAPI "Single" "get/${DP_WETTERDATA}?prettyPrint"
    LC=$(echo $retval | jq -r '.lc')
@@ -715,7 +724,7 @@ setup() {
    unset SOL_ARY; unset SON_ARY; unset SONNENSCHEIN_TMP; unset SOLAR_TMP
 
    #Startwerte setzen
-   SAPI "Bulk" "setBulk" "${DP_WETTER_TREND}=${WETTER_TREND}"
+   SAPI "Bulk" "setBulk" "${DP_WETTER_TREND}=${WETTER_TREND}&ack=true"
 }
 
 
@@ -1556,5 +1565,3 @@ wettercom_update(){
 }
 
 ###EoF
-
-


### PR DESCRIPTION
Fixed authentication for Simple-API setBulk requests (user&pass must be send as GET params),
Set ack flag on setBulk requests (requires PR ioBroker/ioBroker.simple-api#145),
Added option to ignore SSL errors if HTTPS is used together with a self-signed certificate